### PR TITLE
Name Inclusion

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -1,1 +1,2 @@
 
+Joshua Enyi-Christopher


### PR DESCRIPTION
Error Message from my local app. "Authentication failed. You may not have permission to access the repository. Open options and verify that you're signed in with an account that has permission to access this repository."